### PR TITLE
fix whitespace issue in phpmd command block

### DIFF
--- a/src/PhpHooks/Command/ForbiddenCommand.php
+++ b/src/PhpHooks/Command/ForbiddenCommand.php
@@ -35,8 +35,11 @@ class ForbiddenCommand extends BaseCommand
         $files = unserialize($input->getArgument('files'));
 
         foreach ($files as $file) {
-            foreach ($configuration['forbidden']['methods'] as $method) {
+            if (substr($file, -4, 4) !== '.php') {
+                continue;
+            }
 
+            foreach ($configuration['forbidden']['methods'] as $method) {
                 $pattern = $method . '(';
                 $content = file_get_contents($file);
 

--- a/src/PhpHooks/Command/PhpmdCommand.php
+++ b/src/PhpHooks/Command/PhpmdCommand.php
@@ -47,7 +47,7 @@ class PhpmdCommand extends BaseCommand
             $processBuilder
                 ->add($file)
                 ->add('text')
-                ->add($configuration['phpmd']['ruleset']);
+                ->add(preg_replace('/\s+/', null, $configuration['phpmd']['ruleset']));
 
             $this->doExecute($processBuilder);
         }


### PR DESCRIPTION
it seems to be an issue inside our phpmd configuration handling block. whitespace in rulesets will be accepted now. including an additional fix inside forbidden methods command block to handle/scan php files only.
